### PR TITLE
add winc1500 feature

### DIFF
--- a/target.json
+++ b/target.json
@@ -29,7 +29,7 @@
     "mbed-os": {
       "net": {
         "stacks": {
-          "winc1500": true
+          "atmel": true
         }
       }
     },
@@ -94,7 +94,8 @@
     "armv6-m",
     "arm",
     "gcc",
-    "mbed"
+    "mbed",
+    "winc1500"
   ],
   "toolchain": "CMake/toolchain.cmake"
   }


### PR DESCRIPTION
this added feature will not have global scope of "target-atmel-samg55j19-gcc"
- it has the limited scope within "sal" and "sal-stack-atmel"
